### PR TITLE
Add room templates and generate connected boss path

### DIFF
--- a/game/level.py
+++ b/game/level.py
@@ -1,12 +1,39 @@
-
 """Level representation handling entity placement and bounds."""
 
 import random
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Set
 
+from level.room import (
+    BASIC_TEMPLATES,
+    BOSS_ROOM_TEMPLATE,
+    Room,
+    RoomTemplate,
+)
 from .enemy import Enemy
 from .weapon import Weapon
+
+DIRECTION_DELTAS = {"N": (0, -1), "S": (0, 1), "E": (1, 0), "W": (-1, 0)}
+
+
+def _direction(from_pos: Tuple[int, int], to_pos: Tuple[int, int]) -> str:
+    """Return cardinal direction from one coordinate to an adjacent one."""
+    dx = to_pos[0] - from_pos[0]
+    dy = to_pos[1] - from_pos[1]
+    if dx == 1 and dy == 0:
+        return "E"
+    if dx == -1 and dy == 0:
+        return "W"
+    if dy == 1 and dx == 0:
+        return "S"
+    if dy == -1 and dx == 0:
+        return "N"
+    raise ValueError("Positions are not adjacent")
+
+
+def _weighted_choice(templates: List[RoomTemplate]) -> RoomTemplate:
+    weights = [t.weight for t in templates]
+    return random.choices(templates, weights=weights, k=1)[0]
 
 
 @dataclass
@@ -15,7 +42,9 @@ class Level:
     height: int
     enemies: List[Enemy] = field(default_factory=list)
     weapons: List[Weapon] = field(default_factory=list)
-
+    rooms: Dict[Tuple[int, int], Room] = field(default_factory=dict)
+    start_room: Tuple[int, int] = (0, 0)
+    boss_room: Tuple[int, int] = (0, 0)
 
     def clamp_position(self, x: int, y: int) -> Tuple[int, int]:
         """Clamp coordinates to level bounds."""
@@ -25,14 +54,43 @@ class Level:
         """Check if coordinates fall within the level."""
         return 0 <= x < self.width and 0 <= y < self.height
 
-
     def generate(
         self,
         enemy_count: int,
         weapon_count: int = 0,
         weapon_pool: Optional[List[Weapon]] = None,
+        room_templates: Optional[List[RoomTemplate]] = None,
+        boss_room_template: RoomTemplate = BOSS_ROOM_TEMPLATE,
     ) -> Tuple[List[Enemy], List[Weapon]]:
-        """Generate enemies and weapons at random positions within the level."""
+        """Generate enemies, weapons, and a connected path of rooms."""
+        if room_templates is None:
+            room_templates = BASIC_TEMPLATES
+
+        # Assemble rooms with at least one path to a boss room.
+        self.rooms = {}
+        path = [(x, 0) for x in range(self.width)]
+        if self.height > 1:
+            path.extend([(self.width - 1, y) for y in range(1, self.height)])
+        for i, (x, y) in enumerate(path):
+            required: Set[str] = set()
+            if i > 0:
+                required.add(_direction((x, y), path[i - 1]))
+            if i < len(path) - 1:
+                required.add(_direction((x, y), path[i + 1]))
+            if i == len(path) - 1:
+                template = boss_room_template
+            else:
+                candidates = [t for t in room_templates if required <= t.exits]
+                if not candidates:
+                    candidates = room_templates
+                template = _weighted_choice(candidates)
+            self.rooms[(x, y)] = Room(template=template, x=x, y=y, exits=required.copy())
+
+        if path:
+            self.start_room = path[0]
+            self.boss_room = path[-1]
+
+        # Enemy and weapon placement remains unchanged.
         self.enemies = []
         self.weapons = []
         for _ in range(enemy_count):
@@ -49,8 +107,6 @@ class Level:
                 )
         return self.enemies, self.weapons
 
-
     def remove_dead_enemies(self) -> None:
         """Prune enemies that are no longer alive."""
         self.enemies = [e for e in self.enemies if e.is_alive()]
-

--- a/game/player.py
+++ b/game/player.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Optional, TYPE_CHECKING
 
-from dataclasses import dataclass, field
-from typing import List, Optional
-
 
 from .enemy import Enemy
 from .weapon import Weapon
@@ -39,11 +36,6 @@ class Player:
             nx, ny = level.clamp_position(nx, ny)
         self.x, self.y = nx, ny
 
-    def move(self, dx: int, dy: int) -> None:
-        """Move player by delta."""
-        self.x += dx
-        self.y += dy
-
 
     def take_damage(self, dmg: int) -> int:
         """Apply damage after defense and return actual damage dealt."""
@@ -65,10 +57,6 @@ class Player:
     def heal(self, amount: int) -> None:
         """Restore hit points up to maximum."""
         self.hp = min(self.max_hp, self.hp + amount)
-
-        """Add a weapon to inventory and equip it."""
-        self.inventory.append(weapon)
-        self.weapon = weapon
 
 
     def attack_enemy(self, enemy: Enemy) -> int:

--- a/level/room.py
+++ b/level/room.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass, field
+from typing import Set, List
+
+@dataclass(frozen=True)
+class RoomTemplate:
+    """Reusable room definition with exit metadata."""
+    name: str
+    exits: Set[str]
+    weight: int = 1
+
+@dataclass
+class Room:
+    """A placed room within a level."""
+    template: RoomTemplate
+    x: int
+    y: int
+    exits: Set[str] = field(default_factory=set)
+
+# Basic collection of reusable rooms. Exits use compass directions.
+BASIC_TEMPLATES: List[RoomTemplate] = [
+    RoomTemplate("corridor_ew", {"E", "W"}, weight=3),
+    RoomTemplate("corridor_ns", {"N", "S"}, weight=3),
+    RoomTemplate("corner_es", {"E", "S"}, weight=2),
+    RoomTemplate("cross", {"N", "S", "E", "W"}, weight=1),
+]
+
+# Default boss room template, expecting an entrance from the north.
+BOSS_ROOM_TEMPLATE = RoomTemplate("boss", {"N"})

--- a/tests/test_level_generation.py
+++ b/tests/test_level_generation.py
@@ -1,0 +1,35 @@
+from game.level import Level
+from level.room import RoomTemplate
+
+
+def test_room_generation_connectivity_and_bounds():
+    templates = [
+        RoomTemplate("corridor_ew", {"E", "W"}, weight=2),
+        RoomTemplate("corridor_ns", {"N", "S"}, weight=2),
+        RoomTemplate("corner_es", {"E", "S"}, weight=1),
+        RoomTemplate("cross", {"N", "S", "E", "W"}, weight=1),
+    ]
+    boss = RoomTemplate("boss", {"N"})
+    level = Level(width=4, height=4)
+    level.generate(enemy_count=0, room_templates=templates, boss_room_template=boss)
+
+    # All rooms lie within bounds
+    for (x, y) in level.rooms.keys():
+        assert 0 <= x < level.width
+        assert 0 <= y < level.height
+
+    # Check connectivity from start to boss using exits
+    deltas = {"N": (0, -1), "S": (0, 1), "E": (1, 0), "W": (-1, 0)}
+    visited = {level.start_room}
+    stack = [level.start_room]
+    while stack:
+        cx, cy = stack.pop()
+        room = level.rooms[(cx, cy)]
+        for d in room.exits:
+            dx, dy = deltas[d]
+            nx, ny = cx + dx, cy + dy
+            if (nx, ny) in level.rooms and (nx, ny) not in visited:
+                visited.add((nx, ny))
+                stack.append((nx, ny))
+    assert level.boss_room in visited
+    assert len(level.rooms) == level.width + level.height - 1


### PR DESCRIPTION
## Summary
- add reusable room templates with exit metadata
- generate levels from weighted room templates ensuring a path to the boss
- test level generation for connectivity and bounds
- clean up player movement and healing bugs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c02f4fb004832bb814e72ed592f561