### PR TITLE
Add consumable items and inventory usage

### DIFF
--- a/game/items.py
+++ b/game/items.py
@@ -1,0 +1,26 @@
+"""Item definitions used by the game."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used only for typing
+    from .player import Player
+
+
+@dataclass
+class Consumable:
+    """An item that can be consumed to produce an effect on the player."""
+
+    name: str
+    heal: int = 0
+    damage: int = 0
+
+    def use(self, player: Player) -> None:
+        """Apply the consumable's effect to ``player``."""
+        if self.heal:
+            player.heal(self.heal)
+        if self.damage:
+            player.take_damage(self.damage)
+

--- a/game/player.py
+++ b/game/player.py
@@ -1,82 +1,80 @@
+"""Player entity with movement, inventory management and combat helpers."""
 
-"""Player entity with basic movement, inventory and combat helpers."""
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional, TYPE_CHECKING
-
-from dataclasses import dataclass, field
-from typing import List, Optional
-
+from typing import List, Optional, Union, TYPE_CHECKING
 
 from .enemy import Enemy
 from .weapon import Weapon
-
+from .items import Consumable
 
 if TYPE_CHECKING:  # pragma: no cover - for type checking only
     from .level import Level
 
 
+Item = Union[Weapon, Consumable]
+
 
 @dataclass
 class Player:
+    """Player controlled character."""
+
     x: int
     y: int
 
     max_hp: int = 100
-
     hp: int = 100
     attack: int = 10
     defense: int = 5
     weapon: Optional[Weapon] = None
-    inventory: List[Weapon] = field(default_factory=list)
-
+    inventory: List[Item] = field(default_factory=list)
 
     def move(self, dx: int, dy: int, level: Optional[Level] = None) -> None:
-        """Move player by delta and optionally clamp to level bounds."""
+        """Move the player by ``dx``/``dy`` and optionally clamp to level bounds."""
         nx, ny = self.x + dx, self.y + dy
         if level:
             nx, ny = level.clamp_position(nx, ny)
         self.x, self.y = nx, ny
 
-    def move(self, dx: int, dy: int) -> None:
-        """Move player by delta."""
-        self.x += dx
-        self.y += dy
-
-
     def take_damage(self, dmg: int) -> int:
-        """Apply damage after defense and return actual damage dealt."""
+        """Apply damage after defense and return the actual damage dealt."""
         actual = max(1, dmg - self.defense)
         self.hp -= actual
         return actual
 
-    def pick_up(self, weapon: Weapon) -> None:
+    def heal(self, amount: int) -> None:
+        """Restore hit points up to the maximum."""
+        self.hp = min(self.max_hp, self.hp + amount)
 
-        """Add a weapon to inventory without equipping."""
-        if weapon not in self.inventory:
-            self.inventory.append(weapon)
+    def pick_up(self, item: Item) -> None:
+        """Add an item to inventory without equipping or using it."""
+        if item not in self.inventory:
+            self.inventory.append(item)
 
     def equip(self, weapon: Weapon) -> None:
-        """Equip a weapon from inventory."""
+        """Equip a weapon that is already in the inventory."""
         if weapon in self.inventory:
             self.weapon = weapon
 
-    def heal(self, amount: int) -> None:
-        """Restore hit points up to maximum."""
-        self.hp = min(self.max_hp, self.hp + amount)
-
-        """Add a weapon to inventory and equip it."""
-        self.inventory.append(weapon)
-        self.weapon = weapon
-
+    def use_item(self, item: Item) -> None:
+        """Use a consumable or equip a weapon from the inventory."""
+        if item not in self.inventory:
+            return
+        if isinstance(item, Consumable):
+            item.use(self)
+            self.inventory.remove(item)
+        elif isinstance(item, Weapon):
+            self.equip(item)
 
     def attack_enemy(self, enemy: Enemy) -> int:
-        """Attack an enemy using base attack plus equipped weapon."""
-        base = self.attack
+        """Attack an enemy using base attack plus equipped weapon damage."""
+        dmg = self.attack
         if self.weapon:
-            base += self.weapon.damage
-        return enemy.take_damage(base)
+            dmg += self.weapon.damage
+        return enemy.take_damage(dmg)
 
     def is_alive(self) -> bool:
+        """Return ``True`` if the player still has hit points."""
         return self.hp > 0
+

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -1,0 +1,26 @@
+from game.items import Consumable
+from game.player import Player
+
+
+def test_pickup_and_use_healing_consumable():
+    player = Player(x=0, y=0, hp=50)
+    potion = Consumable(name="Potion", heal=30)
+
+    player.pick_up(potion)
+    assert potion in player.inventory
+
+    player.use_item(potion)
+    assert player.hp == 80
+    assert potion not in player.inventory
+
+
+def test_pickup_and_use_damage_consumable():
+    player = Player(x=0, y=0, defense=0)
+    poison = Consumable(name="Poison", damage=20)
+
+    player.pick_up(poison)
+    player.use_item(poison)
+
+    assert player.hp == 80
+    assert poison not in player.inventory
+


### PR DESCRIPTION
## Summary
- Add `Consumable` item type with healing and damage effects
- Rework `Player` inventory to handle weapons and consumables with `use_item`
- Add tests for consumable pickup and usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c02f59b71c832b840127a3566185d2