### PR TITLE
Add upgrade progression system with persistence

### DIFF
--- a/game/player.py
+++ b/game/player.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Optional, TYPE_CHECKING
 
-from dataclasses import dataclass, field
-from typing import List, Optional
-
 
 from .enemy import Enemy
 from .weapon import Weapon
@@ -32,17 +29,12 @@ class Player:
     inventory: List[Weapon] = field(default_factory=list)
 
 
-    def move(self, dx: int, dy: int, level: Optional[Level] = None) -> None:
+    def move(self, dx: int, dy: int, level: Optional["Level"] = None) -> None:
         """Move player by delta and optionally clamp to level bounds."""
         nx, ny = self.x + dx, self.y + dy
         if level:
             nx, ny = level.clamp_position(nx, ny)
         self.x, self.y = nx, ny
-
-    def move(self, dx: int, dy: int) -> None:
-        """Move player by delta."""
-        self.x += dx
-        self.y += dy
 
 
     def take_damage(self, dmg: int) -> int:
@@ -65,10 +57,6 @@ class Player:
     def heal(self, amount: int) -> None:
         """Restore hit points up to maximum."""
         self.hp = min(self.max_hp, self.hp + amount)
-
-        """Add a weapon to inventory and equip it."""
-        self.inventory.append(weapon)
-        self.weapon = weapon
 
 
     def attack_enemy(self, enemy: Enemy) -> int:

--- a/game/progression.py
+++ b/game/progression.py
@@ -1,0 +1,44 @@
+"""Track unlockable upgrades and apply them to players."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from .player import Player
+
+
+@dataclass
+class Progression:
+    """Store unlocked upgrades and handle persistence."""
+
+    upgrades: Dict[str, int] = field(default_factory=dict)
+
+    def unlock(self, name: str, amount: int = 1) -> None:
+        """Unlock or increment an upgrade by a given amount."""
+        self.upgrades[name] = self.upgrades.get(name, 0) + amount
+
+    def apply(self, player: Player) -> None:
+        """Apply upgrades to the provided player instance."""
+        if "max_hp" in self.upgrades:
+            inc = self.upgrades["max_hp"]
+            player.max_hp += inc
+            player.hp += inc
+
+    # -- serialization helpers -------------------------------------------------
+    def to_dict(self) -> Dict[str, int]:
+        return dict(self.upgrades)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, int]) -> "Progression":
+        return cls(upgrades=dict(data))
+
+    def to_json(self) -> str:
+        return json.dumps(self.upgrades)
+
+    @classmethod
+    def from_json(cls, data: str) -> "Progression":
+        if not data:
+            return cls()
+        return cls(upgrades=json.loads(data))

--- a/tests/test_progression.py
+++ b/tests/test_progression.py
@@ -1,0 +1,19 @@
+from game.player import Player
+from game.progression import Progression
+
+
+def test_unlock_and_serialize():
+    prog = Progression()
+    prog.unlock("max_hp", 20)
+    data = prog.to_json()
+    loaded = Progression.from_json(data)
+    assert loaded.upgrades == {"max_hp": 20}
+
+
+def test_apply_max_hp_upgrade():
+    player = Player(x=0, y=0)
+    prog = Progression()
+    prog.unlock("max_hp", 20)
+    prog.apply(player)
+    assert player.max_hp == 120
+    assert player.hp == 120


### PR DESCRIPTION
## Summary
- add `Progression` to manage unlockable upgrades
- support JSON serialization for progression data
- test progression saving, loading, and stat application
- fix player move and heal implementations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c02f632004832ba9a5a112b21ba977