### PR TITLE
Add basic UI package with HUD and inventory rendering

### DIFF
--- a/game/player.py
+++ b/game/player.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Optional, TYPE_CHECKING
 
-from dataclasses import dataclass, field
-from typing import List, Optional
-
 
 from .enemy import Enemy
 from .weapon import Weapon
@@ -32,17 +29,12 @@ class Player:
     inventory: List[Weapon] = field(default_factory=list)
 
 
-    def move(self, dx: int, dy: int, level: Optional[Level] = None) -> None:
+    def move(self, dx: int, dy: int, level: Optional["Level"] = None) -> None:
         """Move player by delta and optionally clamp to level bounds."""
         nx, ny = self.x + dx, self.y + dy
         if level:
             nx, ny = level.clamp_position(nx, ny)
         self.x, self.y = nx, ny
-
-    def move(self, dx: int, dy: int) -> None:
-        """Move player by delta."""
-        self.x += dx
-        self.y += dy
 
 
     def take_damage(self, dmg: int) -> int:
@@ -65,10 +57,6 @@ class Player:
     def heal(self, amount: int) -> None:
         """Restore hit points up to maximum."""
         self.hp = min(self.max_hp, self.hp + amount)
-
-        """Add a weapon to inventory and equip it."""
-        self.inventory.append(weapon)
-        self.weapon = weapon
 
 
     def attack_enemy(self, enemy: Enemy) -> int:

--- a/game/ui/__init__.py
+++ b/game/ui/__init__.py
@@ -1,0 +1,10 @@
+"""UI package providing heads-up display helpers."""
+from .hud import draw_health_bar, draw_weapon_name
+from .inventory import render_inventory_slots, bind_item_keys
+
+__all__ = [
+    "draw_health_bar",
+    "draw_weapon_name",
+    "render_inventory_slots",
+    "bind_item_keys",
+]

--- a/game/ui/hud.py
+++ b/game/ui/hud.py
@@ -1,0 +1,27 @@
+"""Heads-up display rendering utilities."""
+from __future__ import annotations
+
+from typing import Optional
+
+from ..player import Player
+
+
+def draw_health_bar(player: Player, width: int = 10) -> str:
+    """Return a simple text health bar for a player.
+
+    The bar uses ``#`` to represent current health and ``-`` for missing health
+    based on ``width`` segments.
+    """
+    ratio = player.hp / player.max_hp if player.max_hp else 0
+    filled = int(width * ratio)
+    empty = width - filled
+    bar = "#" * filled + "-" * empty
+    return f"HP: [{bar}] {player.hp}/{player.max_hp}"
+
+
+def draw_weapon_name(player: Player) -> str:
+    """Return a string showing the currently equipped weapon name."""
+    name: Optional[str] = None
+    if player.weapon:
+        name = player.weapon.name
+    return f"Weapon: {name or 'None'}"

--- a/game/ui/inventory.py
+++ b/game/ui/inventory.py
@@ -1,0 +1,34 @@
+"""Inventory UI helpers."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from ..weapon import Weapon
+
+
+def render_inventory_slots(items: Iterable[Weapon], slots: int = 5) -> List[str]:
+    """Render inventory slots as simple text labels.
+
+    Parameters
+    ----------
+    items:
+        Weapons to place into slots ordered by preference.
+    slots:
+        Total number of available slots.
+    """
+    labels: List[str] = []
+    items_list = list(items)
+    for idx in range(slots):
+        if idx < len(items_list):
+            labels.append(f"{idx + 1}: {items_list[idx].name}")
+        else:
+            labels.append(f"{idx + 1}: Empty")
+    return labels
+
+
+def bind_item_keys(items: Iterable[Weapon]) -> Dict[str, Weapon]:
+    """Bind numerical keys (1..n) to weapons for quick use."""
+    mapping: Dict[str, Weapon] = {}
+    for idx, item in enumerate(items, start=1):
+        mapping[str(idx)] = item
+    return mapping

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,39 @@
+from game.player import Player
+from game.weapon import Weapon
+from game.ui import (
+    bind_item_keys,
+    draw_health_bar,
+    draw_weapon_name,
+    render_inventory_slots,
+)
+
+
+def test_draw_hud_elements():
+    player = Player(x=0, y=0, hp=50)
+    player.max_hp = 100
+    sword = Weapon(name="Sword", damage=10)
+    player.weapon = sword
+
+    bar = draw_health_bar(player)
+    weapon_str = draw_weapon_name(player)
+
+    assert bar == "HP: [#####-----] 50/100"
+    assert weapon_str == "Weapon: Sword"
+
+
+def test_inventory_render_and_bind():
+    sword = Weapon(name="Sword", damage=10)
+    axe = Weapon(name="Axe", damage=12)
+    inventory = [sword, axe]
+
+    labels = render_inventory_slots(inventory, slots=5)
+    mapping = bind_item_keys(inventory)
+
+    assert labels == [
+        "1: Sword",
+        "2: Axe",
+        "3: Empty",
+        "4: Empty",
+        "5: Empty",
+    ]
+    assert mapping == {"1": sword, "2": axe}


### PR DESCRIPTION
## Summary
- add `ui` package for HUD helpers and inventory display
- expose functions to draw health bar, weapon name, inventory slots and key binds
- fix player movement and heal methods, ensure tests exercise UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c02f68b41c832b9ae8349e0baef5f7