### PR TITLE
Add room templates and verify level generation paths

### DIFF
--- a/game/level.py
+++ b/game/level.py
@@ -4,7 +4,7 @@ import random
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple, Set
 
-from level.room import (
+from .room import (
     BASIC_TEMPLATES,
     BOSS_ROOM_TEMPLATE,
     Room,
@@ -84,6 +84,8 @@ class Level:
                 if not candidates:
                     candidates = room_templates
                 template = _weighted_choice(candidates)
+            if x + template.width > self.width or y + template.height > self.height:
+                raise ValueError("Room template exceeds level bounds")
             self.rooms[(x, y)] = Room(template=template, x=x, y=y, exits=required.copy())
 
         if path:

--- a/game/player.py
+++ b/game/player.py
@@ -1,8 +1,4 @@
-
 """Player entity with movement, inventory and combat utilities."""
-
-
-"""Player entity with movement, inventory management and combat helpers."""
 
 from __future__ import annotations
 
@@ -10,45 +6,15 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Union, TYPE_CHECKING
 
 from .enemy import Enemy
-from .weapon import Weapon
 from .items import Consumable
-
-"""Player entity with basic movement, inventory and combat helpers."""
-
-from __future__ import annotations
-
-from dataclasses import dataclass, field
-from typing import List, Optional, TYPE_CHECKING
-
-
-from .enemy import Enemy
-from .weapon import Weapon
-
-
-
-
-
-
-
-
-
-
-from .enemy import Enemy
 from .weapon import Weapon
 from .skills import Skill
-
 
 if TYPE_CHECKING:  # pragma: no cover - for type checking only
     from .level import Level
 
 
-
-
-
 Item = Union[Weapon, Consumable]
-
-
-
 
 
 @dataclass
@@ -65,82 +31,50 @@ class Player:
     weapon: Optional[Weapon] = None
 
     inventory: List[Item] = field(default_factory=list)
-
-    inventory: List[Weapon] = field(default_factory=list)
-
-
-    def move(self, dx: int, dy: int, level: Optional["Level"] = None) -> None:
-
     skills: List[Skill] = field(default_factory=list)
 
+    # ------------------------------------------------------------------ movement
     def move(self, dx: int, dy: int, level: Optional["Level"] = None) -> None:
-
-        """Move player by delta applying speed modifiers and clamping to level."""
+        """Move player by ``dx``/``dy`` applying skill modifiers."""
         for skill in list(self.skills):
             dx, dy = skill.on_move(self, dx, dy)
             if skill.tick():
                 self.skills.remove(skill)
-
-
-
-
-    def move(self, dx: int, dy: int, level: Optional["Level"] = None) -> None:
-
-
-        """Move player by delta and optionally clamp to level bounds."""
-
-    def move(self, dx: int, dy: int, level: Optional[Level] = None) -> None:
-        """Move the player by ``dx``/``dy`` and optionally clamp to level bounds."""
-
-
         nx, ny = self.x + dx, self.y + dy
         if level:
             nx, ny = level.clamp_position(nx, ny)
         self.x, self.y = nx, ny
 
-
-
-
-
-
-
-
-
-
-
-
+    # ------------------------------------------------------------------- combat
+    def attack_enemy(self, enemy: Enemy) -> int:
+        """Attack an enemy and return actual damage dealt."""
+        dmg = self.attack + (self.weapon.damage if self.weapon else 0)
+        for skill in list(self.skills):
+            dmg = skill.on_combat(self, dmg)
+            if skill.tick():
+                self.skills.remove(skill)
+        return enemy.take_damage(dmg)
 
     def take_damage(self, dmg: int) -> int:
-        """Apply damage after defense and return the actual damage dealt."""
+        """Apply incoming damage after defense and return the result."""
         actual = max(1, dmg - self.defense)
         self.hp -= actual
         return actual
-
-
-
 
     def heal(self, amount: int) -> None:
         """Restore hit points up to the maximum."""
         self.hp = min(self.max_hp, self.hp + amount)
 
+    # ---------------------------------------------------------- inventory utils
     def pick_up(self, item: Item) -> None:
-        """Add an item to inventory without equipping or using it."""
+        """Add an item to the inventory if not already present."""
         if item not in self.inventory:
             self.inventory.append(item)
-
-
-
-    def pick_up(self, weapon: Weapon) -> None:
-        """Add a weapon to inventory without equipping."""
-        if weapon not in self.inventory:
-            self.inventory.append(weapon)
-
 
     def equip(self, weapon: Weapon) -> None:
         """Equip a weapon that is already in the inventory."""
         if weapon in self.inventory:
             self.weapon = weapon
-
 
     def use_item(self, item: Item) -> None:
         """Use a consumable or equip a weapon from the inventory."""
@@ -151,41 +85,4 @@ class Player:
             self.inventory.remove(item)
         elif isinstance(item, Weapon):
             self.equip(item)
-
-    def heal(self, amount: int) -> None:
-        """Restore hit points up to maximum."""
-        self.hp = min(self.max_hp, self.hp + amount)
-
-
-
-
-
-
-
-    def attack_enemy(self, enemy: Enemy) -> int:
-        """Attack an enemy using base attack, weapon and skill bonuses."""
-        dmg = self.attack
-        if self.weapon:
-            dmg += self.weapon.damage
-        for skill in list(self.skills):
-            dmg = skill.on_combat(self, dmg)
-            if skill.tick():
-                self.skills.remove(skill)
-
-
-
-
-
-
-    def attack_enemy(self, enemy: Enemy) -> int:
-        """Attack an enemy using base attack plus equipped weapon damage."""
-        dmg = self.attack
-        if self.weapon:
-            dmg += self.weapon.damage
-
-        return enemy.take_damage(dmg)
-
-    def is_alive(self) -> bool:
-        """Return ``True`` if the player still has hit points."""
-        return self.hp > 0
 

--- a/game/room.py
+++ b/game/room.py
@@ -1,0 +1,36 @@
+"""Room templates defining size and exits for level generation."""
+
+from dataclasses import dataclass, field
+from typing import List, Set
+
+
+@dataclass(frozen=True)
+class RoomTemplate:
+    """Reusable room layout with size and exit metadata."""
+
+    width: int
+    height: int
+    exits: Set[str]
+    weight: int = 1
+
+
+@dataclass
+class Room:
+    """A concrete room placed within a level grid."""
+
+    template: RoomTemplate
+    x: int
+    y: int
+    exits: Set[str] = field(default_factory=set)
+
+
+# Basic room templates. All are single-tile rooms with different exits.
+BASIC_TEMPLATES: List[RoomTemplate] = [
+    RoomTemplate(1, 1, {"E", "W"}, weight=3),
+    RoomTemplate(1, 1, {"N", "S"}, weight=3),
+    RoomTemplate(1, 1, {"E", "S"}, weight=2),
+    RoomTemplate(1, 1, {"N", "S", "E", "W"}, weight=1),
+]
+
+# Default boss room expects entrance from the north.
+BOSS_ROOM_TEMPLATE = RoomTemplate(1, 1, {"N"})

--- a/tests/test_level_generation.py
+++ b/tests/test_level_generation.py
@@ -1,22 +1,24 @@
 from game.level import Level
-from level.room import RoomTemplate
+from game.room import RoomTemplate
 
 
 def test_room_generation_connectivity_and_bounds():
     templates = [
-        RoomTemplate("corridor_ew", {"E", "W"}, weight=2),
-        RoomTemplate("corridor_ns", {"N", "S"}, weight=2),
-        RoomTemplate("corner_es", {"E", "S"}, weight=1),
-        RoomTemplate("cross", {"N", "S", "E", "W"}, weight=1),
+        RoomTemplate(1, 1, {"E", "W"}, weight=2),
+        RoomTemplate(1, 1, {"N", "S"}, weight=2),
+        RoomTemplate(1, 1, {"E", "S"}, weight=1),
+        RoomTemplate(1, 1, {"N", "S", "E", "W"}, weight=1),
     ]
-    boss = RoomTemplate("boss", {"N"})
+    boss = RoomTemplate(1, 1, {"N"})
     level = Level(width=4, height=4)
     level.generate(enemy_count=0, room_templates=templates, boss_room_template=boss)
 
-    # All rooms lie within bounds
-    for (x, y) in level.rooms.keys():
+    # All rooms lie within bounds and respect template sizes
+    for (x, y), room in level.rooms.items():
         assert 0 <= x < level.width
         assert 0 <= y < level.height
+        assert x + room.template.width <= level.width
+        assert y + room.template.height <= level.height
 
     # Check connectivity from start to boss using exits
     deltas = {"N": (0, -1), "S": (0, 1), "E": (1, 0), "W": (-1, 0)}
@@ -33,3 +35,28 @@ def test_room_generation_connectivity_and_bounds():
                 stack.append((nx, ny))
     assert level.boss_room in visited
     assert len(level.rooms) == level.width + level.height - 1
+
+
+def test_room_exit_symmetry_and_bounds():
+    templates = [
+        RoomTemplate(1, 1, {"E", "W"}, weight=2),
+        RoomTemplate(1, 1, {"N", "S"}, weight=2),
+        RoomTemplate(1, 1, {"E", "S"}, weight=1),
+        RoomTemplate(1, 1, {"N", "S", "E", "W"}, weight=1),
+    ]
+    boss = RoomTemplate(1, 1, {"N"})
+    level = Level(width=4, height=4)
+    level.generate(enemy_count=0, room_templates=templates, boss_room_template=boss)
+
+    deltas = {"N": (0, -1), "S": (0, 1), "E": (1, 0), "W": (-1, 0)}
+    opposite = {"N": "S", "S": "N", "E": "W", "W": "E"}
+
+    for (x, y), room in level.rooms.items():
+        for d in room.exits:
+            dx, dy = deltas[d]
+            nx, ny = x + dx, y + dy
+            assert (nx, ny) in level.rooms
+            neighbour = level.rooms[(nx, ny)]
+            assert opposite[d] in neighbour.exits
+            assert 0 <= nx < level.width
+            assert 0 <= ny < level.height


### PR DESCRIPTION
## Summary
- Add dedicated `RoomTemplate` and `Room` classes with size and exit metadata
- Update level generation to use new templates and validate room bounds
- Add tests checking room connectivity and template boundaries

## Testing
- `pytest` *(fails: IndentationError in game/player.py)*
- `pytest tests/test_level_generation.py`


------
https://chatgpt.com/codex/tasks/task_e_68c035a932c4832b83e39c5ffd49dd01