### PR TITLE
docs: clean up README overview reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,7 @@ python main.py
 python -m pytest
 ```
 
-The code includes simple `Player`, `Enemy`, `Level`, and `Weapon` classes to serve as a starting point for further development.
-
-
-For a high-level overview of planned features, see [GDD.md](GDD.md).
-
+The code includes simple `Player`, `Enemy`, `Level`, and `Weapon` classes
+to serve as a starting point for further development.
 
 For a high-level overview of planned features, see [GDD.md](GDD.md).
-


### PR DESCRIPTION
## Summary
- remove duplicate overview sentence in README
- wrap long lines to satisfy markdownlint

## Testing
- `markdownlint README.md`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c03dbb6d00832b971c497024447d5c