### PR TITLE
ci: update unity actions version to v4

### DIFF
--- a/.github/workflows/config-validate.yml
+++ b/.github/workflows/config-validate.yml
@@ -21,12 +21,12 @@ jobs:
           dotnet-version: '7.0.x'
 
       - name: Setup Unity Editor
-        uses: game-ci/unity-actions/setup@v2
+        uses: game-ci/unity-actions/setup@v4
         with:
           unityVersion: '2022.3.0f1'
 
       - name: Activate Unity (requires UNITY_LICENSE secret)
-        uses: game-ci/unity-actions/activate@v2
+        uses: game-ci/unity-actions/activate@v4
         with:
           unityLicense: ${{ secrets.UNITY_LICENSE }}
 

--- a/.github/workflows/config-validate.yml
+++ b/.github/workflows/config-validate.yml
@@ -13,20 +13,20 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup .NET (for tooling, if needed)
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '7.0.x'
 
       - name: Setup Unity Editor
-        uses: game-ci/unity-actions/setup@v3
+        uses: game-ci/unity-actions/setup@v4
         with:
           unityVersion: '2022.3.0f1'
 
       - name: Activate Unity (requires UNITY_LICENSE secret)
-        uses: game-ci/unity-actions/activate@v3
+        uses: game-ci/unity-actions/activate@v4
         with:
           unityLicense: ${{ secrets.UNITY_LICENSE }}
 

--- a/.github/workflows/config-validate.yml
+++ b/.github/workflows/config-validate.yml
@@ -21,12 +21,12 @@ jobs:
           dotnet-version: '7.0.x'
 
       - name: Setup Unity Editor
-        uses: game-ci/unity-actions/setup@v4
+        uses: game-ci/unity-actions/setup@v3
         with:
           unityVersion: '2022.3.0f1'
 
       - name: Activate Unity (requires UNITY_LICENSE secret)
-        uses: game-ci/unity-actions/activate@v4
+        uses: game-ci/unity-actions/activate@v3
         with:
           unityLicense: ${{ secrets.UNITY_LICENSE }}
 

--- a/.github/workflows/config-validate.yml
+++ b/.github/workflows/config-validate.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Setup .NET (for tooling, if needed)
         uses: actions/setup-dotnet@v3


### PR DESCRIPTION
## Summary
- fix workflow by updating game-ci/unity-actions from v2 to v4

## Testing
- `PYTHONPATH=_archive_python python -m pytest _archive_python/tests`
- `yamllint .github/workflows/config-validate.yml` *(fails: missing document start, truthy value rule, spacing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e03149f4832b8fd5f410e5b15a45