### PR TITLE
Allow config validation workflow without Unity license

### DIFF
--- a/.github/workflows/config-validate.yml
+++ b/.github/workflows/config-validate.yml
@@ -27,11 +27,13 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Activate Unity (requires UNITY_LICENSE secret)
+        if: ${{ secrets.UNITY_LICENSE != '' }}
         uses: game-ci/unity-activate@v2
         with:
           unityLicense: ${{ secrets.UNITY_LICENSE }}
 
       - name: Run config validation (batchmode)
+        if: ${{ secrets.UNITY_LICENSE != '' }}
         run: |
           echo "Running config validation"
           $UNITY_PATH/Editor/Unity \
@@ -40,4 +42,8 @@ jobs:
             -executeMethod Game.ConfigValidation.Run \
             -quit -nographics -logFile -
           echo "Config validation passed"
+
+      - name: Smoke config validation
+        if: ${{ secrets.UNITY_LICENSE == '' }}
+        run: echo "UNITY_LICENSE not provided; skipping config validation."
 


### PR DESCRIPTION
## Summary
- skip Unity activation unless a license is configured
- run config validation only when UNITY_LICENSE is set and provide a smoke step otherwise

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1159e602c832b943a7020c1394970