### PR TITLE
Add upgrade system with PlayerStats persistence

### DIFF
--- a/UnityGame/Assets/Configs/PlayerStats.asset
+++ b/UnityGame/Assets/Configs/PlayerStats.asset
@@ -1,0 +1,8 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_Name: PlayerStats
+  m_Script: {fileID: 11500000, guid: 728f34d202be4536b9e34e0fc44f7865, type: 3}
+  currency: 0
+  upgradeLevel: 0

--- a/UnityGame/Assets/Configs/PlayerStats.asset.meta
+++ b/UnityGame/Assets/Configs/PlayerStats.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bce7baa888564f2dbfa7820ffc51775d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityGame/Assets/Scenes/Hub.unity
+++ b/UnityGame/Assets/Scenes/Hub.unity
@@ -14,3 +14,25 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!1 &1000
+GameObject:
+  m_Name: UpgradeTerminal
+  m_Component:
+  - component: {fileID: 1001}
+  - component: {fileID: 1002}
+  m_Layer: 0
+  m_TagString: Untagged
+  m_Active: 1
+--- !u!4 &1001
+Transform:
+  m_GameObject: {fileID: 1000}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!114 &1002
+MonoBehaviour:
+  m_GameObject: {fileID: 1000}
+  m_Enabled: 1
+  m_Script: {fileID: 11500000, guid: dad453fbf451460abf07da703259c5be, type: 3}
+  stats: {fileID: 11400000, guid: bce7baa888564f2dbfa7820ffc51775d, type: 2}
+  baseUpgradeCost: 10

--- a/UnityGame/Assets/Scripts/Core/PlayerStats.cs
+++ b/UnityGame/Assets/Scripts/Core/PlayerStats.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Game/Player Stats")]
+public class PlayerStats : ScriptableObject
+{
+    public int currency;
+    public int upgradeLevel;
+
+    public bool CanAfford(int cost) => currency >= cost;
+
+    public void ApplyUpgrade(int cost)
+    {
+        if (CanAfford(cost))
+        {
+            currency -= cost;
+            upgradeLevel++;
+        }
+    }
+}

--- a/UnityGame/Assets/Scripts/Core/PlayerStats.cs.meta
+++ b/UnityGame/Assets/Scripts/Core/PlayerStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 728f34d202be4536b9e34e0fc44f7865
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityGame/Assets/Scripts/Systems/UpgradeManager.cs
+++ b/UnityGame/Assets/Scripts/Systems/UpgradeManager.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+public class UpgradeManager : MonoBehaviour
+{
+    [SerializeField] private PlayerStats stats;
+    [SerializeField] private int baseUpgradeCost = 10;
+
+    public PlayerStats Stats
+    {
+        get => stats;
+        set => stats = value;
+    }
+
+    public int BaseUpgradeCost
+    {
+        get => baseUpgradeCost;
+        set => baseUpgradeCost = value;
+    }
+
+    public bool PurchaseUpgrade()
+    {
+        int cost = GetUpgradeCost();
+        if (!stats || !stats.CanAfford(cost))
+            return false;
+
+        stats.ApplyUpgrade(cost);
+        return true;
+    }
+
+    public int GetUpgradeCost()
+    {
+        return baseUpgradeCost * (stats != null ? stats.upgradeLevel + 1 : 1);
+    }
+}

--- a/UnityGame/Assets/Scripts/Systems/UpgradeManager.cs.meta
+++ b/UnityGame/Assets/Scripts/Systems/UpgradeManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dad453fbf451460abf07da703259c5be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityGame/Assets/Tests/EditMode/UpgradeManagerTests.cs
+++ b/UnityGame/Assets/Tests/EditMode/UpgradeManagerTests.cs
@@ -1,0 +1,41 @@
+#if UNITY_EDITOR
+using NUnit.Framework;
+using UnityEngine;
+
+public class UpgradeManagerTests
+{
+    [Test]
+    public void PurchaseUpgradeDeductsCurrencyAndIncreasesLevel()
+    {
+        var stats = ScriptableObject.CreateInstance<PlayerStats>();
+        stats.currency = 15;
+        stats.upgradeLevel = 0;
+
+        var go = new GameObject();
+        var manager = go.AddComponent<UpgradeManager>();
+        manager.Stats = stats;
+        manager.BaseUpgradeCost = 10;
+
+        Assert.IsTrue(manager.PurchaseUpgrade());
+        Assert.AreEqual(1, stats.upgradeLevel);
+        Assert.AreEqual(5, stats.currency);
+    }
+
+    [Test]
+    public void PurchaseFailsWithInsufficientCurrency()
+    {
+        var stats = ScriptableObject.CreateInstance<PlayerStats>();
+        stats.currency = 5;
+        stats.upgradeLevel = 0;
+
+        var go = new GameObject();
+        var manager = go.AddComponent<UpgradeManager>();
+        manager.Stats = stats;
+        manager.BaseUpgradeCost = 10;
+
+        Assert.IsFalse(manager.PurchaseUpgrade());
+        Assert.AreEqual(0, stats.upgradeLevel);
+        Assert.AreEqual(5, stats.currency);
+    }
+}
+#endif

--- a/UnityGame/Assets/Tests/EditMode/UpgradeManagerTests.cs.meta
+++ b/UnityGame/Assets/Tests/EditMode/UpgradeManagerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 32c51117d403462c83d3c9237719fef9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add upgrade terminal to Hub scene linked to a new UpgradeManager
- implement UpgradeManager and PlayerStats to handle currency and persistent upgrades
- cover upgrade purchasing and failure cases with edit mode tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c11aad6f4c832ba7e34a3219a1112e