### PR TITLE
Add basic inventory system with tests

### DIFF
--- a/Configs/Items/ItemData.asset
+++ b/Configs/Items/ItemData.asset
@@ -1,0 +1,6 @@
+{
+  "items": [
+    { "id": "sword", "slot": "Weapon", "attack": 5, "defense": 0 },
+    { "id": "shield", "slot": "Offhand", "attack": 0, "defense": 3 }
+  ]
+}

--- a/Configs/Items/ItemData.asset.meta
+++ b/Configs/Items/ItemData.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b9a0102f-20f6-4450-b3a5-69a91f35439f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityGame/Assets/Prefabs/UI/HUD.prefab
+++ b/UnityGame/Assets/Prefabs/UI/HUD.prefab
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component: []
+  m_Layer: 0
+  m_Name: HUD
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1

--- a/UnityGame/Assets/Prefabs/UI/HUD.prefab.meta
+++ b/UnityGame/Assets/Prefabs/UI/HUD.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a6da8db1-cfa5-4caf-b8e5-0b8f67f56599
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityGame/Assets/Prefabs/UI/InventoryPanel.prefab
+++ b/UnityGame/Assets/Prefabs/UI/InventoryPanel.prefab
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component: []
+  m_Layer: 0
+  m_Name: InventoryPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1

--- a/UnityGame/Assets/Prefabs/UI/InventoryPanel.prefab.meta
+++ b/UnityGame/Assets/Prefabs/UI/InventoryPanel.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b6601d2f-7152-4f8f-b996-cb2193632fe5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityGame/Assets/Scripts/Player/EquipmentSlot.cs
+++ b/UnityGame/Assets/Scripts/Player/EquipmentSlot.cs
@@ -1,0 +1,7 @@
+public enum EquipmentSlot
+{
+    Weapon,
+    Offhand,
+    Head,
+    Body
+}

--- a/UnityGame/Assets/Scripts/Player/EquipmentSlot.cs.meta
+++ b/UnityGame/Assets/Scripts/Player/EquipmentSlot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43072323-d8fe-464e-b836-63f2c46d58ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityGame/Assets/Scripts/Player/Inventory.cs
+++ b/UnityGame/Assets/Scripts/Player/Inventory.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+public class Inventory
+{
+    private readonly List<Item> _items = new();
+    private readonly Dictionary<EquipmentSlot, Item> _equipped = new();
+    private readonly PlayerStats _stats = new();
+
+    public void AddItem(Item item)
+    {
+        _items.Add(item);
+    }
+
+    public bool Equip(Item item)
+    {
+        if (!_items.Contains(item))
+            return false;
+        _equipped[item.slot] = item;
+        _stats.attack += item.attack;
+        _stats.defense += item.defense;
+        return true;
+    }
+
+    public bool Contains(Item item) => _items.Contains(item);
+    public PlayerStats Stats => _stats;
+}
+
+public class Item
+{
+    public string id;
+    public EquipmentSlot slot;
+    public int attack;
+    public int defense;
+}
+
+public class PlayerStats
+{
+    public int attack;
+    public int defense;
+}

--- a/UnityGame/Assets/Scripts/Player/Inventory.cs.meta
+++ b/UnityGame/Assets/Scripts/Player/Inventory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 78cf8c16-6c65-4466-88b6-866a9a37383b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityGame/Assets/Scripts/UI/HUD.cs
+++ b/UnityGame/Assets/Scripts/UI/HUD.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+public class HUD : MonoBehaviour
+{
+    [SerializeField] private GameObject inventoryPanel;
+
+    void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.I) && inventoryPanel != null)
+            inventoryPanel.SetActive(!inventoryPanel.activeSelf);
+    }
+}

--- a/UnityGame/Assets/Scripts/UI/HUD.cs.meta
+++ b/UnityGame/Assets/Scripts/UI/HUD.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31ff0340-1e0c-4d9c-ad66-85037b76c2b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityGame/Assets/Tests/EditMode/InventoryTests.cs
+++ b/UnityGame/Assets/Tests/EditMode/InventoryTests.cs
@@ -1,0 +1,35 @@
+#if UNITY_EDITOR
+using NUnit.Framework;
+
+public class InventoryTests
+{
+    [Test]
+    public void ItemPickupAddsToInventory()
+    {
+        var inv = new Inventory();
+        var item = new Item { id = "sword", slot = EquipmentSlot.Weapon, attack = 5 };
+        inv.AddItem(item);
+        Assert.IsTrue(inv.Contains(item));
+    }
+
+    [Test]
+    public void EquipItemAppliesStats()
+    {
+        var inv = new Inventory();
+        var item = new Item { id = "sword", slot = EquipmentSlot.Weapon, attack = 5 };
+        inv.AddItem(item);
+        inv.Equip(item);
+        Assert.AreEqual(5, inv.Stats.attack);
+    }
+
+    [Test]
+    public void EquipItemIncreasesDefense()
+    {
+        var inv = new Inventory();
+        var item = new Item { id = "shield", slot = EquipmentSlot.Offhand, defense = 3 };
+        inv.AddItem(item);
+        inv.Equip(item);
+        Assert.AreEqual(3, inv.Stats.defense);
+    }
+}
+#endif

--- a/UnityGame/Assets/Tests/EditMode/InventoryTests.cs.meta
+++ b/UnityGame/Assets/Tests/EditMode/InventoryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1217e003-8cbc-41fa-9d0e-5ffc7f4f9076
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add simple inventory and equipment slot scripts
- add item definitions and HUD/inventory UI prefabs
- cover pickup, equip and stat changes in new tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c11aaebd18832b8b9433cf15de7522