### PR TITLE
Add sprite import pipeline and validation

### DIFF
--- a/Docs/art-pipeline.md
+++ b/Docs/art-pipeline.md
@@ -1,0 +1,15 @@
+# Art Pipeline
+
+## Sprite Import Settings
+
+- **Naming**: Sprite textures must start with `spr_` and reside under `Assets/Art`.
+- **Type**: Imported as *Sprite (2D and UI)*.
+- **Compression**: Uses `Compressed` texture compression.
+- **Mip Maps**: Disabled.
+
+### Workflow
+1. Drop the PNG into `Assets/Art` with a `spr_` prefix.
+2. The `AssetPostprocessor` automatically applies import settings and warns on naming errors.
+3. Verify in the Inspector that the sprite type and compression match the guidelines.
+
+These rules ensure consistent, memory‑efficient textures across the project.

--- a/UnityGame/Assets/Configs/assets_manifest.csv
+++ b/UnityGame/Assets/Configs/assets_manifest.csv
@@ -1,10 +1,10 @@
 path,type,usage,expected_size,notes
-Art/Characters/player.png,sprite,player character,256KB,final sprite sheet placeholder
-Art/Characters/player_weapon.png,sprite,player weapon,128KB,
-Art/Enemies/slime.png,sprite,basic enemy,128KB,
-Art/Enemies/goblin.png,sprite,basic enemy,128KB,
-Art/Props/health_potion.png,sprite,item icon,32KB,
-Art/UI/hud.png,sprite,HUD elements,64KB,
+Art/Characters/spr_player.png,sprite,player character,256KB,final sprite sheet placeholder
+Art/Characters/spr_player_weapon.png,sprite,player weapon,128KB,
+Art/Enemies/spr_slime.png,sprite,basic enemy,128KB,
+Art/Enemies/spr_goblin.png,sprite,basic enemy,128KB,
+Art/Props/spr_health_potion.png,sprite,item icon,32KB,
+Art/UI/spr_hud.png,sprite,HUD elements,64KB,
 Audio/Music/hub_theme.ogg,audio,hub background music,2MB,loop
 Audio/Music/biome_a_theme.ogg,audio,biome A BGM,3MB,loop
 Audio/SFX/jump.wav,audio,player jump,64KB,

--- a/UnityGame/Assets/Editor/SpriteImportPostprocessor.cs
+++ b/UnityGame/Assets/Editor/SpriteImportPostprocessor.cs
@@ -1,0 +1,23 @@
+using UnityEditor;
+using UnityEngine;
+using System.IO;
+
+public class SpriteImportPostprocessor : AssetPostprocessor
+{
+    private const string Prefix = "spr_";
+
+    void OnPreprocessTexture()
+    {
+        var importer = (TextureImporter)assetImporter;
+        string fileName = Path.GetFileNameWithoutExtension(assetPath);
+
+        if (!fileName.StartsWith(Prefix))
+        {
+            Debug.LogError($"Sprite '{assetPath}' must start with '{Prefix}'.");
+        }
+
+        importer.textureType = TextureImporterType.Sprite;
+        importer.textureCompression = TextureImporterCompression.Compressed;
+        importer.mipmapEnabled = false;
+    }
+}

--- a/UnityGame/Assets/Tests/EditMode/SpriteImportSmokeTests.cs
+++ b/UnityGame/Assets/Tests/EditMode/SpriteImportSmokeTests.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using System.IO;
+
+public class SpriteImportSmokeTests
+{
+    private const string TempPath = "Assets/Art/Placeholders/spr_temp.png";
+
+    [Test]
+    public void ImportedSpriteHasExpectedSettings()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(TempPath));
+
+        var tex = new Texture2D(2, 2);
+        tex.SetPixels(new[] { Color.white, Color.white, Color.white, Color.white });
+        tex.Apply();
+        File.WriteAllBytes(TempPath, tex.EncodeToPNG());
+        Object.DestroyImmediate(tex);
+
+        AssetDatabase.ImportAsset(TempPath, ImportAssetOptions.ForceUpdate);
+        var importer = (TextureImporter)AssetImporter.GetAtPath(TempPath);
+
+        Assert.AreEqual(TextureImporterType.Sprite, importer.textureType);
+        Assert.AreEqual(TextureImporterCompression.Compressed, importer.textureCompression);
+        Assert.IsFalse(importer.mipmapEnabled);
+
+        AssetDatabase.DeleteAsset(TempPath);
+    }
+}


### PR DESCRIPTION
## Summary
- document art pipeline sprite import guidelines
- auto-enforce sprite naming and compression via AssetPostprocessor
- add smoke test ensuring importer settings are applied

## Testing
- `unity-editor -batchmode -projectPath UnityGame -runTests -testPlatform editmode -logFile -` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c11ab31a14832bb2237c108ab1e84b