### PR TITLE
Implement save system with UI hooks and tests

### DIFF
--- a/UnityGame/Assets/Scripts/Systems/SaveData.cs
+++ b/UnityGame/Assets/Scripts/Systems/SaveData.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+
+[Serializable]
+public class SaveData
+{
+    public PlayerStats stats = new PlayerStats();
+    public List<string> inventory = new List<string>();
+    public PlayerProgress progress = new PlayerProgress();
+}
+
+[Serializable]
+public class PlayerStats
+{
+    public int level;
+    public int health;
+    public int experience;
+}
+
+[Serializable]
+public class PlayerProgress
+{
+    public string checkpoint;
+    public int stage;
+}

--- a/UnityGame/Assets/Scripts/Systems/SaveData.cs.meta
+++ b/UnityGame/Assets/Scripts/Systems/SaveData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42f9f906ebe4442eb48f031b19ccd12d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityGame/Assets/Scripts/Systems/SaveSystem.cs
+++ b/UnityGame/Assets/Scripts/Systems/SaveSystem.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using UnityEngine;
+
+public static class SaveSystem
+{
+    public static string SavePath = Path.Combine(Application.persistentDataPath, "save.json");
+    public static SaveData CurrentData = new SaveData();
+
+    public static void Save()
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(CurrentData);
+            File.WriteAllText(SavePath, json);
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"Save failed: {e.Message}");
+        }
+    }
+
+    public static void Load()
+    {
+        try
+        {
+            if (!File.Exists(SavePath))
+            {
+                Debug.LogWarning("Save file not found");
+                CurrentData = new SaveData();
+                return;
+            }
+            var json = File.ReadAllText(SavePath);
+            CurrentData = JsonSerializer.Deserialize<SaveData>(json) ?? new SaveData();
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"Load failed: {e.Message}");
+            CurrentData = new SaveData();
+        }
+    }
+}

--- a/UnityGame/Assets/Scripts/Systems/SaveSystem.cs.meta
+++ b/UnityGame/Assets/Scripts/Systems/SaveSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d60428e9f6cd4f3fab35b0c480af17d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityGame/Assets/Scripts/UI/SaveLoadUI.cs
+++ b/UnityGame/Assets/Scripts/UI/SaveLoadUI.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+public class SaveLoadUI : MonoBehaviour
+{
+    public void SaveGame()
+    {
+        SaveSystem.Save();
+    }
+
+    public void LoadGame()
+    {
+        SaveSystem.Load();
+    }
+}

--- a/UnityGame/Assets/Scripts/UI/SaveLoadUI.cs.meta
+++ b/UnityGame/Assets/Scripts/UI/SaveLoadUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16e6911acfd2444493d5dabaceff14ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityGame/Assets/Tests/EditMode/SaveSystemTests.cs
+++ b/UnityGame/Assets/Tests/EditMode/SaveSystemTests.cs
@@ -1,0 +1,40 @@
+#if UNITY_EDITOR
+using NUnit.Framework;
+using System.IO;
+using UnityEngine;
+
+public class SaveSystemTests
+{
+    [Test]
+    public void SaveAndLoadData()
+    {
+        var tempPath = Path.Combine(Application.dataPath, "test_save.json");
+        var prevPath = SaveSystem.SavePath;
+
+        var data = new SaveData
+        {
+            stats = { level = 5, health = 80, experience = 1200 },
+            inventory = { "sword", "potion" },
+            progress = { checkpoint = "Hub", stage = 3 }
+        };
+
+        SaveSystem.SavePath = tempPath;
+        SaveSystem.CurrentData = data;
+        SaveSystem.Save();
+
+        SaveSystem.CurrentData = new SaveData();
+        SaveSystem.Load();
+        var loaded = SaveSystem.CurrentData;
+
+        Assert.AreEqual(data.stats.level, loaded.stats.level);
+        Assert.AreEqual(data.stats.health, loaded.stats.health);
+        Assert.AreEqual(data.stats.experience, loaded.stats.experience);
+        CollectionAssert.AreEqual(data.inventory, loaded.inventory);
+        Assert.AreEqual(data.progress.checkpoint, loaded.progress.checkpoint);
+        Assert.AreEqual(data.progress.stage, loaded.progress.stage);
+
+        File.Delete(tempPath);
+        SaveSystem.SavePath = prevPath;
+    }
+}
+#endif

--- a/UnityGame/Assets/Tests/EditMode/SaveSystemTests.cs.meta
+++ b/UnityGame/Assets/Tests/EditMode/SaveSystemTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9a604a85f524ab797cd92f54d85f337
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add JSON-based `SaveSystem` and `SaveData` classes for persisting player stats, inventory, and progress
- expose save/load controls via reusable UI component
- cover save-load cycle with an edit-mode test

## Testing
- `dotnet test` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c11ab26598832b94fd053c6821dca7