### PR TITLE
Add dummy enemy and basic combat system

### DIFF
--- a/UnityGame/Assets/Scripts/Combat/PlayerCombat.cs
+++ b/UnityGame/Assets/Scripts/Combat/PlayerCombat.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Damage))]
+public class PlayerCombat : MonoBehaviour
+{
+    private Damage damage;
+
+    private void Awake()
+    {
+        damage = GetComponent<Damage>();
+    }
+
+    public void Attack(GameObject target)
+    {
+        if (damage != null)
+        {
+            damage.DealDamage(target);
+        }
+    }
+}

--- a/UnityGame/Assets/Scripts/Combat/PlayerCombat.cs.meta
+++ b/UnityGame/Assets/Scripts/Combat/PlayerCombat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b1364441bdc4b87a26a436ff3953bdd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityGame/Assets/Scripts/Common/Damage.cs
+++ b/UnityGame/Assets/Scripts/Common/Damage.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Collider))]
+public class Damage : MonoBehaviour
+{
+    [SerializeField] private int amount = 1;
+    public int Amount
+    {
+        get => amount;
+        set => amount = value;
+    }
+
+    public void DealDamage(GameObject target)
+    {
+        var health = target.GetComponent<Health>();
+        if (health != null)
+        {
+            health.TakeDamage(amount);
+        }
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        DealDamage(other.gameObject);
+    }
+
+    private void OnCollisionEnter(Collision collision)
+    {
+        DealDamage(collision.gameObject);
+    }
+}

--- a/UnityGame/Assets/Scripts/Common/Damage.cs.meta
+++ b/UnityGame/Assets/Scripts/Common/Damage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f1d7c72e04e4f66baaaf249093d2059
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityGame/Assets/Scripts/Common/Health.cs
+++ b/UnityGame/Assets/Scripts/Common/Health.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+public class Health : MonoBehaviour
+{
+    [SerializeField] private int maxHealth = 100;
+    public int MaxHealth => maxHealth;
+    public int Current { get; private set; }
+    public bool IsDead => Current <= 0;
+
+    private void Awake()
+    {
+        Current = maxHealth;
+    }
+
+    public void TakeDamage(int amount)
+    {
+        Current = Mathf.Max(0, Current - amount);
+    }
+}

--- a/UnityGame/Assets/Scripts/Common/Health.cs.meta
+++ b/UnityGame/Assets/Scripts/Common/Health.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c46b65ddc30c43f696fa577d7e63b6eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityGame/Assets/Scripts/Enemies/DummyEnemy.cs
+++ b/UnityGame/Assets/Scripts/Enemies/DummyEnemy.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Health))]
+public class DummyEnemy : MonoBehaviour
+{
+    [SerializeField] public float moveSpeed = 2f;
+    [SerializeField] public float chaseRange = 5f;
+    [SerializeField] public float attackRange = 1f;
+    [SerializeField] public int contactDamage = 10;
+    [SerializeField] private float attackCooldown = 1f;
+
+    private Transform player;
+    private float attackTimer;
+
+    private void Update()
+    {
+        if (player == null)
+        {
+            var playerObj = GameObject.FindWithTag("Player");
+            if (playerObj != null)
+            {
+                player = playerObj.transform;
+            }
+            else
+            {
+                return;
+            }
+        }
+
+        float distance = Vector3.Distance(transform.position, player.position);
+        if (distance <= attackRange)
+        {
+            attackTimer -= Time.deltaTime;
+            if (attackTimer <= 0f)
+            {
+                var health = player.GetComponent<Health>();
+                if (health != null)
+                {
+                    health.TakeDamage(contactDamage);
+                }
+                attackTimer = attackCooldown;
+            }
+        }
+        else if (distance <= chaseRange)
+        {
+            transform.position = Vector3.MoveTowards(transform.position, player.position, moveSpeed * Time.deltaTime);
+        }
+    }
+}

--- a/UnityGame/Assets/Scripts/Enemies/DummyEnemy.cs.meta
+++ b/UnityGame/Assets/Scripts/Enemies/DummyEnemy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d02f2e9c831436fa747cfd7284e3894
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityGame/Assets/Tests/EditMode/EnemyTests.cs
+++ b/UnityGame/Assets/Tests/EditMode/EnemyTests.cs
@@ -1,0 +1,54 @@
+#if UNITY_EDITOR
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+public class EnemyTests
+{
+    [Test]
+    public void PursuesTargetWithinRange()
+    {
+        var player = new GameObject("Player");
+        player.tag = "Player";
+        player.transform.position = Vector3.right * 2f;
+
+        var enemy = new GameObject("Enemy");
+        var dummy = enemy.AddComponent<DummyEnemy>();
+        dummy.moveSpeed = 1f;
+        dummy.chaseRange = 5f;
+
+        var update = typeof(DummyEnemy).GetMethod("Update", BindingFlags.Instance | BindingFlags.NonPublic);
+        update.Invoke(dummy, null);
+
+        Assert.Greater(enemy.transform.position.x, 0f);
+
+        Object.DestroyImmediate(player);
+        Object.DestroyImmediate(enemy);
+    }
+
+    [Test]
+    public void DamageExchangedOnAttack()
+    {
+        var player = new GameObject("Player");
+        player.tag = "Player";
+        var playerHealth = player.AddComponent<Health>();
+        var playerDamage = player.AddComponent<Damage>();
+        playerDamage.Amount = 7;
+        var playerCombat = player.AddComponent<PlayerCombat>();
+
+        var enemy = new GameObject("Enemy");
+        var enemyHealth = enemy.AddComponent<Health>();
+        var enemyDamage = enemy.AddComponent<Damage>();
+        enemyDamage.Amount = 5;
+
+        playerCombat.Attack(enemy);
+        Assert.AreEqual(enemyHealth.MaxHealth - 7, enemyHealth.Current);
+
+        enemyDamage.DealDamage(player);
+        Assert.AreEqual(playerHealth.MaxHealth - 5, playerHealth.Current);
+
+        Object.DestroyImmediate(player);
+        Object.DestroyImmediate(enemy);
+    }
+}
+#endif

--- a/UnityGame/Assets/Tests/EditMode/EnemyTests.cs.meta
+++ b/UnityGame/Assets/Tests/EditMode/EnemyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c17d65dbc32744cb8b37be6c7ba6781f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add reusable `Health` and `Damage` components
- implement `DummyEnemy` with chase and attack logic
- create `PlayerCombat` wrapper and edit-mode tests for pursuit and damage

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c11aa60db4832b948a674707c94d65